### PR TITLE
Patch GP RCP

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -147,6 +147,12 @@ jobs:
           sdk_args=""
           for sdk_dir in /*_sdk*; do
             sdk_args="$sdk_args --sdk $sdk_dir"
+
+            for patch in "$PWD/sdk_patches"/*.patch
+            do
+                echo "Patching ${patch}"
+                patch -p1 -d "$sdk_dir" < $patch
+            done
           done
 
           # Pass all toolchains as consecutive `--toolchain ...` arguments

--- a/sdk_patches/openthread-efr32-radio-enable-gp.patch
+++ b/sdk_patches/openthread-efr32-radio-enable-gp.patch
@@ -1,0 +1,38 @@
+diff --git a/protocol/openthread/platform-abstraction/efr32/radio.c b/protocol/openthread/platform-abstraction/efr32/radio.c
+index 1d3863c2..b6c60d3a 100644
+--- a/protocol/openthread/platform-abstraction/efr32/radio.c
++++ b/protocol/openthread/platform-abstraction/efr32/radio.c
+@@ -3286,14 +3286,14 @@ static void processNextRxPacket(otInstance *aInstance)
+         else
+ #endif // OPENTHREAD_CONFIG_DIAG_ENABLE
+         {
+-            bool isGpPacket = sl_gp_intf_is_gp_pkt(&sReceive.frame);
+-#if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
++            // bool isGpPacket = sl_gp_intf_is_gp_pkt(&sReceive.frame);
++// #if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+             // For multipan RCP, continue normal processing.
+-            OT_UNUSED_VARIABLE(isGpPacket);
+-#else
++            // OT_UNUSED_VARIABLE(isGpPacket);
++// #else
+             // Else, we should not receive GP packets.
+-            otEXPECT(!isGpPacket);
+-#endif
++            // otEXPECT(!isGpPacket);
++// #endif
+ 
+ #if OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+             (void)sl_gp_intf_should_buffer_pkt(instance, &sReceive.frame, true);
+@@ -3306,9 +3306,9 @@ static void processNextRxPacket(otInstance *aInstance)
+     railDebugCounters.mRailPlatRadioReceiveDoneCbCount++;
+ #endif
+ 
+-#if !OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
+-exit:
+-#endif
++// #if !OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE
++// exit:
++// #endif
+     IgnoreError(sl_memory_pool_free(&sRxPacketMemPoolHandle, rxPacketBuf));
+     otSysEventSignalPending();
+ }


### PR DESCRIPTION
GP component intended for Multipan use prevents the reception of NWK GP frames if Multipan is not enabled. This patch removes that restriction and allows receiving GP frames in [ZoH](https://github.com/Nerivec/zigbee-on-host)-like use of `STREAM_RAW`.