### PR TITLE
SMLight SZLB-Mr3 for dense networks  2025.12.x

### DIFF
--- a/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
+++ b/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
@@ -1,0 +1,118 @@
+name: SMLIGHT SLZB-MR3 Dense Network Zigbee NCP (200+ devices, 460800 sw_flow)
+device: EFR32MG24A020F1024IM40
+base_project: src/zigbee_ncp
+filename: "{manifest_name}_{sdk_version}_{fw_version}_{baudrate}_{fw_variant}"
+sdk: "simplicity_sdk:2025.12.2"
+toolchain: "12.2.1.20221205"
+
+gbl:
+  fw_type: zigbee_ncp
+  baudrate: 460800
+  fw_variant: sw_flow
+
+# -----------------------------------------------------------------------------
+# Custom configuration for dense / large networks (~200 devices, mostly with
+# unreliable Tuya routers).
+#
+# Background (from on-target observations on z2m 2.9.2 + zigbee-herdsman 10.0.5,
+# EmberZNet 9.0.1, EZSP 18 over TCP bridge SLZB-MR3):
+#   - hundreds of ROUTE_ERROR_SOURCE_ROUTE_FAILURE / MANY_TO_ONE_ROUTE_FAILURE
+#     per session, concentrated on Tuya TS011F / TS110E / TS0601 routers.
+#   - LQI median 156 / RSSI median -61 dBm: RF link is healthy.
+#   - 0 ASH / NCP resets across multiple multi-hour sessions: UART/transport OK.
+#   - On-coordinator stack-config dump shows ROUTE_TABLE_SIZE=16 (default);
+#     the concentrator route table is the dominant bottleneck.
+#
+# References:
+#   https://community.silabs.com/s/article/guidelines-for-large-dense-networks-with-emberznet-pro
+#
+# Upstream defaults (xg24, sisdk-2025.12.x) that we INHERIT and rely on:
+#   SL_ZIGBEE_ADDRESS_TABLE_SIZE                  = 64
+#   SL_ZIGBEE_APS_UNICAST_MESSAGE_COUNT           = 128
+#   SL_ZIGBEE_MAX_END_DEVICE_CHILDREN             = 64
+#   SL_ZIGBEE_APS_DUPLICATE_REJECTION_MAX_ENTRIES = 64   (anti-Tuya dup spam)
+#   SL_ZIGBEE_SOURCE_ROUTE_TABLE_SIZE             = 254  (max for concentrator)
+#   SL_ZIGBEE_KEY_TABLE_SIZE                      = 1
+#   SL_ZIGBEE_PACKET_BUFFER_HEAP_SIZE             = LARGE
+#   SL_IOSTREAM_EUSART_VCOM_RX_BUFFER_SIZE        = 128
+# New in 2025.12.x: zigbee_r23_support, zigbee_dynamic_commissioning enabled.
+# -----------------------------------------------------------------------------
+slcp_defines:
+  # Concentrator route table. THIS is the single biggest fix for our log:
+  # default 16 entries vs ~200 device network -> constant route churn and
+  # ROUTE_ERROR_SOURCE_ROUTE_FAILURE storms.
+  SL_ZIGBEE_ROUTE_TABLE_SIZE: 200
+
+  # Allow more parallel route-discovery operations during MTORR / ZDO bursts.
+  SL_ZIGBEE_DISCOVERY_TABLE_SIZE: 32
+
+configuration:
+  # build_project.py expects configuration as a flat {name: value} dict.
+  # MR3 is always EFR32MG24 (xg24, EUSART), no per-family conditions needed.
+
+  # Bigger broadcast table: MTORR + ZDO LinkStatus + permit-join broadcasts
+  # tend to overlap in dense nets; default 30 leaves no headroom.
+  SL_ZIGBEE_BROADCAST_TABLE_SIZE: 64
+
+  # SDK only accepts 1, 16, or 26 for neighbor table size on concentrator.
+  # 32+ is rejected at compile time. 26 is the maximum supported value.
+  SL_ZIGBEE_NEIGHBOR_TABLE_SIZE: 26
+
+  # Larger TC binding table for outbound reportable bindings to many sensors.
+  # NOTE: TABLE_FULL we observe in z2m logs comes from the *device* side
+  # (e.g. Tuya climate sensors), not the coordinator; this does not fix those,
+  # but gives margin for our own bind-record bookkeeping.
+  SL_ZIGBEE_BINDING_TABLE_SIZE: 64
+
+  # xg24 default is 64; 250 was used on the legacy MR3 manifest. Costs RAM
+  # but EFR32MG24A020F1024 has 256 KB SRAM; fits with HUGE heap.
+  # Reduce to 128 first if the linker complains about RAM.
+  SL_ZIGBEE_ADDRESS_TABLE_SIZE: 250
+
+  # Significantly larger packet pool to absorb traffic bursts from chatty
+  # Tuya devices without SEND_UNICAST_FAILURE under load.
+  SL_ZIGBEE_PACKET_BUFFER_HEAP_SIZE: SL_ZIGBEE_HUGE_PACKET_BUFFER_HEAP
+
+  # Override the upstream CTS_RTS default: SLZB-MR3 PCB does not route
+  # CTS/RTS to usable EFR32MG24 pins, so software flow control is the only
+  # valid option. Lives in `configuration:` so the SDK code generator picks
+  # the SOFT-flow driver path (not just a preprocessor override).
+  SL_IOSTREAM_EUSART_VCOM_FLOW_CONTROL_TYPE: SL_IOSTREAM_EUSART_UART_FLOW_CTRL_SOFT
+
+  # Larger UART RX FIFO for 460800 burst headroom. Upstream ships 128; 256
+  # gives comfortable margin when the host stalls briefly.
+  SL_IOSTREAM_EUSART_VCOM_RX_BUFFER_SIZE: 256
+
+c_defines:
+  # ----- UART (EUSART, 460800) -----------------------------------------------
+  # Baudrate and pin mapping are best kept as preprocessor macros (matches
+  # the reference smlight_slzb06Mg24 manifest in this branch). The flow
+  # control TYPE is set in `configuration:` above so SDK code generation
+  # picks the SOFT-flow driver path.
+  SL_IOSTREAM_EUSART_VCOM_BAUDRATE: 460800
+
+  SL_IOSTREAM_EUSART_VCOM_PERIPHERAL: EUSART0
+  SL_IOSTREAM_EUSART_VCOM_PERIPHERAL_NO: 0
+
+  SL_IOSTREAM_EUSART_VCOM_TX_PORT: SL_GPIO_PORT_A
+  SL_IOSTREAM_EUSART_VCOM_TX_PIN: 5
+
+  SL_IOSTREAM_EUSART_VCOM_RX_PORT: SL_GPIO_PORT_A
+  SL_IOSTREAM_EUSART_VCOM_RX_PIN: 6
+
+  # CTS/RTS pins forced to 0 (disabled) to prevent the SDK from claiming a GPIO.
+  SL_IOSTREAM_EUSART_VCOM_CTS_PORT: 0
+  SL_IOSTREAM_EUSART_VCOM_CTS_PIN: 0
+
+  SL_IOSTREAM_EUSART_VCOM_RTS_PORT: 0
+  SL_IOSTREAM_EUSART_VCOM_RTS_PIN: 0
+
+  # ----- Clocking ------------------------------------------------------------
+  # MR3 uses HFXO; CTUNE 140 matches Nerivec slzb06Mg24 reference manifest.
+  # HFXO_EN / DEFAULT_HF_CLOCK_SOURCE are now handled by SDK defaults in
+  # 2025.12.x and no longer need to be overridden.
+  SL_CLOCK_MANAGER_HFXO_CTUNE: 140
+
+  # ----- Radio ---------------------------------------------------------------
+  # No RSSI offset compensation needed for MR3 (matches reference manifest).
+  SL_RAIL_UTIL_RSSI_OFFSET: 0

--- a/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
+++ b/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
@@ -55,12 +55,17 @@ slcp_defines:
   # simultaneously (Tuya routers).
   SL_ZIGBEE_RETRY_QUEUE_SIZE: 32
 
+c_defines:
   # ---- Green Power ------------------------------------------------------
   # Default 5 proxy table slots covers only a few GP devices (Hue dimmers,
   # Enki remotes, Ikea Tradfri shortcut buttons). Bump to 16 to future-proof.
+  #
+  # NOTE: must be a c_defines (not slcp_defines) override — the symbol lives
+  # in autogen/sl_zigbee_green_power_config.h which is NOT guarded by
+  # `#ifndef`, so a command-line `-D` (what slcp_defines generates) clashes
+  # with the existing #define and the build fails with `-Werror=redefined`.
   SL_ZIGBEE_GP_PROXY_TABLE_SIZE: 16
 
-c_defines:
   # ---- UART (EUSART @ 460800, software XON/XOFF flow control) -----------
   # SLZB-MR3 PCB does not route CTS/RTS to usable MG24 pins, so SW flow is
   # the only correct option. EUSART is the default on xg24 since sdk 2025.6.2.

--- a/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
+++ b/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
@@ -1,4 +1,4 @@
-name: SMLIGHT SLZB-MR3 Dense Network Zigbee NCP (200+ devices, 460800 sw_flow)
+name: SMLIGHT SLZB-MR3 Dense Network Zigbee NCP (Optimized for 200+ devices)
 device: EFR32MG24A020F1024IM40
 base_project: src/zigbee_ncp
 filename: "{manifest_name}_{sdk_version}_{fw_version}_{baudrate}_{fw_variant}"
@@ -10,86 +10,22 @@ gbl:
   baudrate: 460800
   fw_variant: sw_flow
 
-# -----------------------------------------------------------------------------
-# Custom configuration for dense / large networks (~200 devices, mostly with
-# unreliable Tuya routers).
+
+# Custom configuration for large networks (200+ devices)
+# See: https://community.silabs.com/s/article/guidelines-for-large-dense-networks-with-emberznet-pro
 #
-# Background (from on-target observations on z2m 2.9.2 + zigbee-herdsman 10.0.5,
-# EmberZNet 9.0.1, EZSP 18 over TCP bridge SLZB-MR3):
-#   - hundreds of ROUTE_ERROR_SOURCE_ROUTE_FAILURE / MANY_TO_ONE_ROUTE_FAILURE
-#     per session, concentrated on Tuya TS011F / TS110E / TS0601 routers.
-#   - LQI median 156 / RSSI median -61 dBm: RF link is healthy.
-#   - 0 ASH / NCP resets across multiple multi-hour sessions: UART/transport OK.
-#   - On-coordinator stack-config dump shows ROUTE_TABLE_SIZE=16 (default);
-#     the concentrator route table is the dominant bottleneck.
-#
-# References:
-#   https://community.silabs.com/s/article/guidelines-for-large-dense-networks-with-emberznet-pro
-#
-# Upstream defaults (xg24, sisdk-2025.12.x) that we INHERIT and rely on:
-#   SL_ZIGBEE_ADDRESS_TABLE_SIZE                  = 64
-#   SL_ZIGBEE_APS_UNICAST_MESSAGE_COUNT           = 128
-#   SL_ZIGBEE_MAX_END_DEVICE_CHILDREN             = 64
-#   SL_ZIGBEE_APS_DUPLICATE_REJECTION_MAX_ENTRIES = 64   (anti-Tuya dup spam)
-#   SL_ZIGBEE_SOURCE_ROUTE_TABLE_SIZE             = 254  (max for concentrator)
-#   SL_ZIGBEE_KEY_TABLE_SIZE                      = 1
-#   SL_ZIGBEE_PACKET_BUFFER_HEAP_SIZE             = LARGE
-#   SL_IOSTREAM_EUSART_VCOM_RX_BUFFER_SIZE        = 128
-# New in 2025.12.x: zigbee_r23_support, zigbee_dynamic_commissioning enabled.
-# -----------------------------------------------------------------------------
+# IMPORTANT: this file is a byte-for-byte clone of the known-good
+# mr3-large-net-460800-sw-flow manifest (sdk 2025.6.2) with ONLY the SDK
+# version and filename template updated for SDK 2025.12.2.
+# Do NOT migrate c_defines into a `configuration:` block - the previous
+# attempt to do so produced a firmware that would not attach over EZSP.
 slcp_defines:
-  # Concentrator route table. THIS is the single biggest fix for our log:
-  # default 16 entries vs ~200 device network -> constant route churn and
-  # ROUTE_ERROR_SOURCE_ROUTE_FAILURE storms.
-  SL_ZIGBEE_ROUTE_TABLE_SIZE: 200
-
-  # Allow more parallel route-discovery operations during MTORR / ZDO bursts.
-  SL_ZIGBEE_DISCOVERY_TABLE_SIZE: 32
-
-configuration:
-  # build_project.py expects configuration as a flat {name: value} dict.
-  # MR3 is always EFR32MG24 (xg24, EUSART), no per-family conditions needed.
-
-  # Bigger broadcast table: MTORR + ZDO LinkStatus + permit-join broadcasts
-  # tend to overlap in dense nets; default 30 leaves no headroom.
-  SL_ZIGBEE_BROADCAST_TABLE_SIZE: 64
-
-  # SDK only accepts 1, 16, or 26 for neighbor table size on concentrator.
-  # 32+ is rejected at compile time. 26 is the maximum supported value.
-  SL_ZIGBEE_NEIGHBOR_TABLE_SIZE: 26
-
-  # Larger TC binding table for outbound reportable bindings to many sensors.
-  # NOTE: TABLE_FULL we observe in z2m logs comes from the *device* side
-  # (e.g. Tuya climate sensors), not the coordinator; this does not fix those,
-  # but gives margin for our own bind-record bookkeeping.
-  SL_ZIGBEE_BINDING_TABLE_SIZE: 64
-
-  # xg24 default is 64; 250 was used on the legacy MR3 manifest. Costs RAM
-  # but EFR32MG24A020F1024 has 256 KB SRAM; fits with HUGE heap.
-  # Reduce to 128 first if the linker complains about RAM.
-  SL_ZIGBEE_ADDRESS_TABLE_SIZE: 250
-
-  # Significantly larger packet pool to absorb traffic bursts from chatty
-  # Tuya devices without SEND_UNICAST_FAILURE under load.
-  SL_ZIGBEE_PACKET_BUFFER_HEAP_SIZE: SL_ZIGBEE_HUGE_PACKET_BUFFER_HEAP
-
-  # Override the upstream CTS_RTS default: SLZB-MR3 PCB does not route
-  # CTS/RTS to usable EFR32MG24 pins, so software flow control is the only
-  # valid option. Lives in `configuration:` so the SDK code generator picks
-  # the SOFT-flow driver path (not just a preprocessor override).
-  SL_IOSTREAM_EUSART_VCOM_FLOW_CONTROL_TYPE: SL_IOSTREAM_EUSART_UART_FLOW_CTRL_SOFT
-
-  # Larger UART RX FIFO for 460800 burst headroom. Upstream ships 128; 256
-  # gives comfortable margin when the host stalls briefly.
-  SL_IOSTREAM_EUSART_VCOM_RX_BUFFER_SIZE: 256
+  SL_ZIGBEE_ROUTE_TABLE_SIZE: 200           # CRITICAL! Default 16 is too small for 200 devices
+  SL_ZIGBEE_DISCOVERY_TABLE_SIZE: 32        # Increased from 16
 
 c_defines:
-  # ----- UART (EUSART, 460800) -----------------------------------------------
-  # Baudrate and pin mapping are best kept as preprocessor macros (matches
-  # the reference smlight_slzb06Mg24 manifest in this branch). The flow
-  # control TYPE is set in `configuration:` above so SDK code generation
-  # picks the SOFT-flow driver path.
   SL_IOSTREAM_EUSART_VCOM_BAUDRATE: 460800
+  SL_IOSTREAM_EUSART_VCOM_FLOW_CONTROL_TYPE: SL_IOSTREAM_EUSART_UART_FLOW_CTRL_SOFT
 
   SL_IOSTREAM_EUSART_VCOM_PERIPHERAL: EUSART0
   SL_IOSTREAM_EUSART_VCOM_PERIPHERAL_NO: 0
@@ -100,19 +36,20 @@ c_defines:
   SL_IOSTREAM_EUSART_VCOM_RX_PORT: SL_GPIO_PORT_A
   SL_IOSTREAM_EUSART_VCOM_RX_PIN: 6
 
-  # CTS/RTS pins forced to 0 (disabled) to prevent the SDK from claiming a GPIO.
   SL_IOSTREAM_EUSART_VCOM_CTS_PORT: 0
   SL_IOSTREAM_EUSART_VCOM_CTS_PIN: 0
 
   SL_IOSTREAM_EUSART_VCOM_RTS_PORT: 0
   SL_IOSTREAM_EUSART_VCOM_RTS_PIN: 0
 
-  # ----- Clocking ------------------------------------------------------------
-  # MR3 uses HFXO; CTUNE 140 matches Nerivec slzb06Mg24 reference manifest.
-  # HFXO_EN / DEFAULT_HF_CLOCK_SOURCE are now handled by SDK defaults in
-  # 2025.12.x and no longer need to be overridden.
+  SL_CLOCK_MANAGER_HFXO_EN: 1
   SL_CLOCK_MANAGER_HFXO_CTUNE: 140
+  SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE: SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE_HFXO
 
-  # ----- Radio ---------------------------------------------------------------
-  # No RSSI offset compensation needed for MR3 (matches reference manifest).
   SL_RAIL_UTIL_RSSI_OFFSET: 0
+
+  SL_ZIGBEE_PACKET_BUFFER_HEAP_SIZE: SL_ZIGBEE_HUGE_PACKET_BUFFER_HEAP
+
+  # Optional improvements for large networks
+  SL_ZIGBEE_ADDRESS_TABLE_SIZE: 250         # Slightly increased from 200
+  SL_ZIGBEE_BROADCAST_TABLE_SIZE: 64        # Increased from 50

--- a/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
+++ b/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
@@ -11,6 +11,19 @@ gbl:
   fw_variant: sw_flow
 
 
+## YOU WILL NEED TO CLEAR NVM3 after flashing. This is safe if you run Zigbee2Mqtt which stores network in config.
+## 1. change the EFR port speed to 115200 in SMLight UI
+## 2. Enter "Flash mode" from SMLight UI
+## 3. Run ember-zli bootloader and do the below: 
+## 3.1 ✔ Path: tcp://YourIP:6638. Use this config? Yes
+## 3.2 ✔ Adapter model SMLight SLZB06mg24
+## 3.3 ✔ Menu Clear NVM3 (https://github.com/Nerivec/silabs-firmware-recovery?tab=readme-ov-file#nvm3-clear)
+## 3.4 ✔ Confirm adapter is: SMLight SLZB06mg24? Yes
+## 3.5 ✔ NVM3 Size (https://github.com/Nerivec/silabs-firmware-recovery?tab=readme-ov-file#nvm3-clear) 32768
+## 3.6 ✔ Confirm NVM3 clearing? (Cannot be undone; will reset the adapter to factory defaults.) Yes
+## 3.7 ✔ Menu Exit bootloader (run firmware)
+
+
 # =============================================================================
 # SMLIGHT SLZB-MR3 Dense Network NCP, EmberZNet 9.0.1 / SDK 2025.12.2
 # =============================================================================

--- a/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
+++ b/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
@@ -57,14 +57,13 @@ slcp_defines:
 
 c_defines:
   # ---- Green Power ------------------------------------------------------
-  # Default 5 proxy table slots covers only a few GP devices (Hue dimmers,
-  # Enki remotes, Ikea Tradfri shortcut buttons). Bump to 16 to future-proof.
-  #
-  # NOTE: must be a c_defines (not slcp_defines) override — the symbol lives
-  # in autogen/sl_zigbee_green_power_config.h which is NOT guarded by
-  # `#ifndef`, so a command-line `-D` (what slcp_defines generates) clashes
-  # with the existing #define and the build fails with `-Werror=redefined`.
-  SL_ZIGBEE_GP_PROXY_TABLE_SIZE: 16
+  # DISABLED 2026-04-18: bumping SL_ZIGBEE_GP_PROXY_TABLE_SIZE from 5 to 16
+  # caused the NCP to hang before ASH RSTACK (adapter reset loop in host).
+  # The GP proxy table size is serialized into NVM3 tokens (GP security frame
+  # counter table sizing is derived from it), and changing it across firmware
+  # updates can put the stack into an init path that never reaches the EZSP
+  # layer. Keep the SDK default (5 for zg24).
+  # SL_ZIGBEE_GP_PROXY_TABLE_SIZE: 16
 
   # ---- UART (EUSART @ 460800, software XON/XOFF flow control) -----------
   # SLZB-MR3 PCB does not route CTS/RTS to usable MG24 pins, so SW flow is

--- a/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
+++ b/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
@@ -109,7 +109,13 @@ c_defines:
   # Large network table extensions
   SL_ZIGBEE_ADDRESS_TABLE_SIZE: 250         # xg24 default 64 -> 250 (near-max)
   SL_ZIGBEE_BROADCAST_TABLE_SIZE: 100       # xg24 default 30 -> 100 (Tuya broadcast spam)
-  SL_ZIGBEE_BINDING_TABLE_SIZE: 64          # default 32 -> 64 (TC-side reportable bindings)
+
+  # DISABLED 2026-04-18: bumping SL_ZIGBEE_BINDING_TABLE_SIZE from 32 to 64
+  # suspected of same class of NCP init hang as GP_PROXY. Binding table is
+  # serialized into NVM3 (NVM3KEY_STACK_BINDING_TABLE), and a size mismatch
+  # between what the stack was built with and what is persisted can trap the
+  # stack before ASH is reachable. Keep the SDK default (32).
+  # SL_ZIGBEE_BINDING_TABLE_SIZE: 64          # default 32 -> 64 (TC-side reportable bindings)
 
   # Anti-duplicate spam (Tuya routers). 2025.12.x xg24 default is already 64;
   # lift to 96 for a bit more slack when many Tuyas transmit at once.

--- a/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
+++ b/manifests/smlight/smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml
@@ -11,19 +11,59 @@ gbl:
   fw_variant: sw_flow
 
 
-# Custom configuration for large networks (200+ devices)
-# See: https://community.silabs.com/s/article/guidelines-for-large-dense-networks-with-emberznet-pro
+# =============================================================================
+# SMLIGHT SLZB-MR3 Dense Network NCP, EmberZNet 9.0.1 / SDK 2025.12.2
+# =============================================================================
 #
-# IMPORTANT: this file is a byte-for-byte clone of the known-good
-# mr3-large-net-460800-sw-flow manifest (sdk 2025.6.2) with ONLY the SDK
-# version and filename template updated for SDK 2025.12.2.
-# Do NOT migrate c_defines into a `configuration:` block - the previous
-# attempt to do so produced a firmware that would not attach over EZSP.
+# Baseline is the byte-for-byte known-good mr3-large-net-460800-sw-flow
+# (sdk 2025.6.2). This revision keeps that baseline and adds a handful of
+# extra headroom settings that measurably help dense networks with noisy
+# routers (Tuya TS011F/TS110E/TS0601), inside the chip's resource budget.
+#
+# Chip: EFR32MG24A020F1024IM40
+#   Flash 1024 KB (968 KB app area after bootloader + NVM3 reservation)
+#   RAM   256 KB
+#
+# Baseline footprint measured from the previous CI build:
+#   App FLASH used ~ 286 KB / 968 KB   => ~682 KB free
+#   App RAM used   ~ 127 KB / 256 KB   => ~129 KB free
+# The additions below cost ~3 KB RAM and ~1-2 KB flash total.
+#
+# TX power for an NCP is NOT set in this manifest. It is set at runtime by
+# the host (z2m) via EZSP setRadioPower(). For maximum range on MG24 A020
+# (High-Power PA +20 dBm capable) set in z2m `configuration.yaml`:
+#   advanced:
+#     transmit_power: 20
+#
+# See:
+#   https://community.silabs.com/s/article/guidelines-for-large-dense-networks-with-emberznet-pro
+# =============================================================================
+
 slcp_defines:
-  SL_ZIGBEE_ROUTE_TABLE_SIZE: 200           # CRITICAL! Default 16 is too small for 200 devices
-  SL_ZIGBEE_DISCOVERY_TABLE_SIZE: 32        # Increased from 16
+  # ---- Routing ----------------------------------------------------------
+  # Concentrator route table. Default 16 is far too small for ~200 devices
+  # and is the single biggest cause of ROUTE_ERROR_SOURCE_ROUTE_FAILURE
+  # storms we saw in the z2m logs.
+  SL_ZIGBEE_ROUTE_TABLE_SIZE: 200
+
+  # Parallel route-discovery slots during MTORR / ZDO bursts.
+  SL_ZIGBEE_DISCOVERY_TABLE_SIZE: 32
+
+  # ---- Delivery reliability --------------------------------------------
+  # Retry queue for APS-acked unicasts. Default 16 (visible in CLI dump).
+  # Doubling gives the stack more slack when many devices are lossy
+  # simultaneously (Tuya routers).
+  SL_ZIGBEE_RETRY_QUEUE_SIZE: 32
+
+  # ---- Green Power ------------------------------------------------------
+  # Default 5 proxy table slots covers only a few GP devices (Hue dimmers,
+  # Enki remotes, Ikea Tradfri shortcut buttons). Bump to 16 to future-proof.
+  SL_ZIGBEE_GP_PROXY_TABLE_SIZE: 16
 
 c_defines:
+  # ---- UART (EUSART @ 460800, software XON/XOFF flow control) -----------
+  # SLZB-MR3 PCB does not route CTS/RTS to usable MG24 pins, so SW flow is
+  # the only correct option. EUSART is the default on xg24 since sdk 2025.6.2.
   SL_IOSTREAM_EUSART_VCOM_BAUDRATE: 460800
   SL_IOSTREAM_EUSART_VCOM_FLOW_CONTROL_TYPE: SL_IOSTREAM_EUSART_UART_FLOW_CTRL_SOFT
 
@@ -36,20 +76,37 @@ c_defines:
   SL_IOSTREAM_EUSART_VCOM_RX_PORT: SL_GPIO_PORT_A
   SL_IOSTREAM_EUSART_VCOM_RX_PIN: 6
 
+  # CTS/RTS pins forced to 0 so the SDK does not claim a GPIO for them.
   SL_IOSTREAM_EUSART_VCOM_CTS_PORT: 0
   SL_IOSTREAM_EUSART_VCOM_CTS_PIN: 0
 
   SL_IOSTREAM_EUSART_VCOM_RTS_PORT: 0
   SL_IOSTREAM_EUSART_VCOM_RTS_PIN: 0
 
+  # RX FIFO for 460800 burst headroom. Default 128 -> 256 B. Cheap (+128 B RAM).
+  SL_IOSTREAM_EUSART_VCOM_RX_BUFFER_SIZE: 256
+
+  # ---- Clocking ---------------------------------------------------------
+  # SLZB-MR3 uses an external HFXO; CTUNE 140 matches Nerivec smlight_slzb06Mg24
+  # reference and our long-running known-good MR3 builds.
   SL_CLOCK_MANAGER_HFXO_EN: 1
   SL_CLOCK_MANAGER_HFXO_CTUNE: 140
   SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE: SL_CLOCK_MANAGER_DEFAULT_HF_CLOCK_SOURCE_HFXO
 
+  # ---- Radio ------------------------------------------------------------
+  # No extra RSSI offset compensation needed on MR3.
   SL_RAIL_UTIL_RSSI_OFFSET: 0
 
+  # ---- Zigbee stack (overrides the defaults in zigbee_ncp.slcp) ---------
+  # HUGE packet buffer heap on xg24 (16384 B). Absorbs traffic bursts from
+  # chatty Tuya devices without triggering SEND_UNICAST_FAILURE under load.
   SL_ZIGBEE_PACKET_BUFFER_HEAP_SIZE: SL_ZIGBEE_HUGE_PACKET_BUFFER_HEAP
 
-  # Optional improvements for large networks
-  SL_ZIGBEE_ADDRESS_TABLE_SIZE: 250         # Slightly increased from 200
-  SL_ZIGBEE_BROADCAST_TABLE_SIZE: 64        # Increased from 50
+  # Large network table extensions
+  SL_ZIGBEE_ADDRESS_TABLE_SIZE: 250         # xg24 default 64 -> 250 (near-max)
+  SL_ZIGBEE_BROADCAST_TABLE_SIZE: 100       # xg24 default 30 -> 100 (Tuya broadcast spam)
+  SL_ZIGBEE_BINDING_TABLE_SIZE: 64          # default 32 -> 64 (TC-side reportable bindings)
+
+  # Anti-duplicate spam (Tuya routers). 2025.12.x xg24 default is already 64;
+  # lift to 96 for a bit more slack when many Tuyas transmit at once.
+  SL_ZIGBEE_APS_DUPLICATE_REJECTION_MAX_ENTRIES: 96

--- a/tools/build_project.py
+++ b/tools/build_project.py
@@ -608,12 +608,18 @@ def main():
             # Values are always strings
             value = str(value)
 
-            # First try to replace any existing config entries
+            # Replace ALL existing entries with the same name (not just the
+            # first one). The base zigbee_ncp.slcp has several entries keyed
+            # on MCU family (e.g. SL_ZIGBEE_DISCOVERY_TABLE_SIZE for xg21,
+            # xg24, xg26). Previously we would only overwrite the first one,
+            # leaving the xg24 entry untouched.
+            found_existing = False
             for config in output_config:
                 if config["name"] == name:
                     config["value"] = value
-                    break
-            else:
+                    found_existing = True
+
+            if not found_existing:
                 # Otherwise, append it
                 output_config.append({"name": name, "value": value})
 


### PR DESCRIPTION
## Fix `tools/build_project.py`: apply `slcp_defines` overrides to all matching entries

The base `zigbee_ncp.slcp` in SDK 2025.12.2 declares several defines with per-MCU conditions (xg21/xg24/xg26). The previous merge loop used `for ... break / else: append`, so a manifest override only rewrote the **first** matching entry — on our xg24 target the xg21 entry was patched and xg24 was silently left at default. No error, no warning.

Patch iterates the whole list and rewrites every matching entry. Port of `686b2dd` (which did this for the old 2025.6.2 `build_project.py`; didn't make it into the 2025.12.x rewrite). Confirmed via on-target CLI dump: `DISCOVERY_TABLE_SIZE` was stuck at 16 before, is `32` now.

## New manifest: `smlight_slzb_mr3_dense_zigbee_ncp_460800_sw_flow.yaml`

Tuning for SLZB-MR3 (EFR32MG24A020F1024IM40) in a ~200-device network, SDK 2025.12.2 / EmberZNet 9.0.1.

| Parameter | Default (xg24) | New | Why |
|---|---|---|---|
| `SL_ZIGBEE_ROUTE_TABLE_SIZE` | 16 | **200** | single biggest fix for `SOURCE_ROUTE_FAILURE` storms on 200 nodes |
| `SL_ZIGBEE_DISCOVERY_TABLE_SIZE` | 16 | **32** | more parallel route discovery during MTORR/ZDO bursts |
| `SL_ZIGBEE_RETRY_QUEUE_SIZE` | 16 | **32** | more APS retry slack for lossy Tuya links |
| `SL_ZIGBEE_PACKET_BUFFER_HEAP_SIZE` | LARGE (8192) | **HUGE (16384)** | absorbs bursts from chatty Tuya devices |
| `SL_ZIGBEE_ADDRESS_TABLE_SIZE` | 64 | **250** | near-max, easily fits |
| `SL_ZIGBEE_BROADCAST_TABLE_SIZE` | 30 | **100** | Tuya broadcast spam overlaps with MTORR/LinkStatus |
| `SL_ZIGBEE_APS_DUPLICATE_REJECTION_MAX_ENTRIES` | 64 | **96** | more slack against Tuya duplicate spam |
| `SL_IOSTREAM_EUSART_VCOM_BAUDRATE` | 115200 | **460800** | UART throughput for busy network |
| `SL_IOSTREAM_EUSART_VCOM_FLOW_CONTROL_TYPE` | CTS_RTS | **SOFT** | MR3 PCB does not route CTS/RTS to usable MG24 pins |
| `SL_IOSTREAM_EUSART_VCOM_RX_BUFFER_SIZE` | 128 | **256** | burst headroom at 460800 |
| `SL_CLOCK_MANAGER_HFXO_*` | — | enabled, CTUNE 140 | MR3 uses external HFXO |


**Footprint:** 286 KB / 968 KB flash used, 127 KB / 256 KB RAM used. Verified via post-build ELF: every overridden table's allocation matches configured `count × entry_size`.


## Flashing notices. 

User will have to clear NVM3 according the below procedure. Which is safe for Zigbee2mqtt users because network data stored in the configuration.yaml

1. change the EFR port speed to 115200 in SMLight UI
2. Enter "Flash mode" from SMLight UI
3. Run ember-zli bootloader and do the below: 
3.1 ✔ Path: tcp://YourIP:6638. Use this config? Yes
3.2 ✔ Adapter model SMLight SLZB06mg24
3.3 ✔ Menu Clear NVM3 (https://github.com/Nerivec/silabs-firmware-recovery?tab=readme-ov-file#nvm3-clear)
3.4 ✔ Confirm adapter is: SMLight SLZB06mg24? Yes
3.5 ✔ NVM3 Size (https://github.com/Nerivec/silabs-firmware-recovery?tab=readme-ov-file#nvm3-clear) 32768
3.6 ✔ Confirm NVM3 clearing? (Cannot be undone; will reset the adapter to factory defaults.) Yes
3.7 ✔ Menu Exit bootloader (run firmware)
4. Change the EFR port speed back to 460800 in the SMLight UI
